### PR TITLE
Add processing model section and examples.

### DIFF
--- a/index.html
+++ b/index.html
@@ -451,7 +451,8 @@ Codecs are the basic primitive for compressing typed values in a generic way. Se
 is for compressing JSON-LD terms. Registry dictionaries are for compressing typed values in a
 use-case-specific way. Each of these is optional — CBOR-LD can be used with any, all, or none of
 these compression strategies. Taken together, the set of these strategies that is used for
-a particular use case is known as a <i>processing model</i>.
+a particular use case is known as a <dfn>processing model</dfn>. Processing models are
+described in detail in <a href="#processing-models"></a>.
     </p>
   </section>
   <section class="informative">
@@ -485,6 +486,176 @@ If and when the original JSON-LD is required, decoding from CBOR-LD to JSON-LD c
 of replacing every CBOR byte value with the associated key from the term-codec map.
       </li>
     </ol>
+  </section>
+
+  <section class="informative">
+    <h1>Processing Models</h1>
+    <p>
+As described in <a href="#basic-concept"></a>, the particular set of compression and
+conversion strategies used for a given use case is known as a <a>processing model</a>.
+Every CBOR-LD payload is associated with exactly one processing model, selected by the
+<a>CBOR-LD Registry Entry</a> whose identifier is carried in the payload's CBOR tag (see
+<a href="#cbor-tags-for-cbor-ld"></a>).
+    </p>
+    <p>
+A processing model determines how an implementation transforms a JSON-LD document to and
+from CBOR-LD. Concretely, a processing model specifies:
+    </p>
+    <ul>
+      <li>
+Whether semantic compression is applied (see <a href="#semantic-compression"></a>),
+      </li>
+      <li>
+Which codecs are used for typed-value compression, together with the
+JSON-LD types to which each codec is applied (see <a href="#codecs"></a>).
+      </li>
+    </ul>
+    <p>
+The registry dictionaries used for use-case-specific, typed-value compression are a distinct
+part of a <a>CBOR-LD Registry Entry</a>, configured through its `typeTables` field (see
+<a href="#cbor-ld-registry"></a>). They are selected independently of the processing model
+and are not part of it.
+    </p>
+    <section>
+      <h2>The Default Processing Model</h2>
+      <p>
+A <a>CBOR-LD Registry Entry</a> that does not specify a `processingModel` uses the
+<dfn>default processing model</dfn>. The default processing model is defined by this
+specification and behaves as follows:
+      </p>
+      <ul>
+        <li>
+Semantic compression is enabled. Term identifiers are auto-generated from the JSON-LD
+contexts referenced by the document, as described in <a href="#semantic-compression"></a>
+and specified by the algorithms in <a href="#algorithms"></a>: the compressible terms
+contributed by those contexts are sorted into Unicode code point order and assigned
+consecutive integers, so that a producer and a consumer that start from the same contexts
+derive identical term identifiers.
+        </li>
+        <li>
+Typed values are compressed using the generic codecs defined in <a href="#codecs"></a>,
+including the URL codecs, the `xsd:date` and `xsd:dateTime` codecs, and the multibase
+codec, each applied on the basis of the JSON-LD type associated with a value.
+        </li>
+      </ul>
+      <p>
+Values whose type has no applicable codec or `typeTable` entry, and terms not covered by
+any referenced context, are carried through unchanged, so that any conforming JSON-LD
+document can be round-tripped without loss.
+      </p>
+    </section>
+
+    <section class="normative">
+      <h2>Expressing a Processing Model</h2>
+      <p>
+When present, the `processingModel` member of a <a>CBOR-LD Registry Entry</a> is a map with
+the members defined below. When the member is absent, the <a>default processing model</a>
+applies.
+      </p>
+      <dl>
+        <dt>`semanticCompression`</dt>
+        <dd>
+OPTIONAL. A boolean indicating whether semantic compression is applied to JSON-LD terms. When
+absent, its value is `true`. When `true`, term identifiers are auto-generated as described in
+<a href="#semantic-compression"></a>; this specification does not define any alternative
+term-identifier assignment scheme.
+        </dd>
+        <dt>`codecs`</dt>
+        <dd>
+OPTIONAL. A map from a <dfn>type key</dfn> to a <dfn>codec identifier</dfn>. A type key is
+either a JSON-LD type expressed as an IRI, or one of the reserved keys `url`, which matches
+node references and values whose term is defined with an `@type` of `@id`, and
+`none`, which matches values that have no type. A codec identifier is one of the values listed
+in <a href="#codec-identifiers"></a>. During conversion, the codec bound to a value's type key,
+if any, is used to compress and decompress that value. When `codecs` is absent, no generic
+typed-value codecs are applied.
+        </dd>
+      </dl>
+
+      <section id="codec-identifiers">
+        <h3>Codec Identifiers</h3>
+        <p>
+This specification defines the codec identifiers in the table below. A processing model defined
+by another specification MAY use additional codec identifiers, provided that specification
+defines the corresponding codec.
+        </p>
+        <table class="simple">
+          <thead>
+            <tr>
+              <th>Codec identifier</th>
+              <th>Codec</th>
+              <th>Type key it is bound to in the <a>default processing model</a></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>`url`</td>
+              <td><a href="#url-codec">URL Codec</a></td>
+              <td>`url`</td>
+            </tr>
+            <tr>
+              <td>`xsd-date`</td>
+              <td><a href="#xsd-date-codec">XSD Date Codec</a></td>
+              <td>`http://www.w3.org/2001/XMLSchema#date`</td>
+            </tr>
+            <tr>
+              <td>`xsd-date-time`</td>
+              <td><a href="#xsd-datetime-codec">XSD DateTime Codec</a></td>
+              <td>`http://www.w3.org/2001/XMLSchema#dateTime`</td>
+            </tr>
+            <tr>
+              <td>`multibase`</td>
+              <td><a href="#multibase-codec">Multibase Codec</a></td>
+              <td>`https://w3id.org/security#multibase`</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h3>Example: The Default Processing Model</h3>
+        <p>
+Expressed in this form, the <a>default processing model</a> enables semantic compression and
+binds each codec defined by this specification to the type it compresses:
+        </p>
+        <pre class="example" title="The default processing model, expressed explicitly">
+processingModel:
+  semanticCompression: true
+  codecs:
+    url: url
+    "http://www.w3.org/2001/XMLSchema#date": xsd-date
+    "http://www.w3.org/2001/XMLSchema#dateTime": xsd-date-time
+    "https://w3id.org/security#multibase": multibase
+        </pre>
+        <p>
+Because this is the default, a registry entry MAY omit the `processingModel` member entirely
+and obtain identical behavior.
+        </p>
+      </section>
+
+      <section>
+        <h3>Example: A Custom Processing Model</h3>
+        <p>
+A registry entry can depart from the default. Consider a use case whose documents seldom
+reference external JSON-LD contexts — so semantic compression offers little benefit — but which
+frequently carry timestamps. A processing model for that use case might disable semantic
+compression and enable only the `xsd:dateTime` codec:
+        </p>
+        <pre class="example" title="A processing model with semantic compression disabled">
+processingModel:
+  semanticCompression: false
+  codecs:
+    "http://www.w3.org/2001/XMLSchema#dateTime": xsd-date-time
+        </pre>
+        <p>
+An encoder using this model leaves JSON-LD terms uncompressed while still replacing
+`xsd:dateTime` values with their compact byte encodings. A decoder, having selected the same
+model from the registry entry identifier, inverts exactly those transformations. A custom model
+could equally bind a type to a codec introduced by another specification, or omit `codecs`
+entirely to perform semantic compression alone.
+        </p>
+      </section>
+    </section>
   </section>
 
   <section class="normative">
@@ -531,21 +702,37 @@ for decompression. A <dfn>CBOR-LD Registry Entry</dfn> contains the following:
 `Use Case`: The type of CBOR-LD payload this entry is to be used for.
           </li>
           <li>
-`typeTables`: An array containing the registry dictionaries that are to be used with this
-registry entry.
+`typeTables`: The collection of registry dictionaries used with this registry entry. Each
+registry dictionary is identified by a <dfn>type table type</dfn> and maps values of that
+type to integers for compact encoding. A type table type is either one of the reserved
+categories (`context` which applies to context values or `url` which applies to `@id` typed
+URL values) or a JSON-LD type identifier, in which case the dictionary
+applies to typed-literal values of that type. See <a href="#value-codec"></a> for how these
+dictionaries are selected and applied during encoding and decoding.
           </li>
           <li>
-`processingModel`: what processing model is used for this registry entry. A processing model
+`processingModel`: The <a>processing model</a> used for this registry entry. If this field
+is absent, the registry entry uses the <a>default processing model</a>. A processing model
 specifies the following:
             <ul>
               <li>
-Whether or not semantic compression is used for dynamic JSON-LD term compression,
+whether or not semantic compression is used for dynamic JSON-LD term compression and, when
+it is, how context-based, auto-generated term identifiers are assigned,
               </li>
               <li>
-The codecs used for dynamic typed-value compression.
+the core, generic codecs used for dynamic typed-value compression — for example the codecs
+for URLs, for `xsd:date` and `xsd:dateTime` values, and for multibase-encoded values — and
+the JSON-LD types to which each is applied, and
+              </li>
+              <li>
+any additional conversion behavior a consumer needs in order to process, or to losslessly
+recover the original JSON-LD document from, the CBOR-LD payload.
               </li>
             </ul>
-The `default` processing model uses semantic compression and includes the codecs specified in this document.
+The <a>default processing model</a> uses semantic compression and includes the codecs
+specified in this document. See <a href="#processing-models"></a> for a full description, and
+<a href="#expressing-a-processing-model"></a> for how the `processingModel` member is
+expressed, including a worked example of the default model.
           </li>
           <li>
 `provisional`: a boolean indicating whether the entry is provisional. Provisional entries

--- a/index.html
+++ b/index.html
@@ -633,8 +633,8 @@ and obtain identical behavior.
       <section>
         <h3>Example: A Custom Processing Model</h3>
         <p>
-If a user does not wish semantic compression to be used, or wishes different
-codecs to be used than those in the default processing model, a registry entry can specify a
+If a user does not wish semantic compression to be used, and/or wishes to compress with
+codecs other than those in the default processing model, a registry entry can specify a
 custom processing model. The following is an example of a processing model without semantic
 compression and for which only the `xsd-date-time` codec is used:
         </p>
@@ -650,12 +650,12 @@ processingModel:
         <p>
 <a href="#codec-identifiers"></a> lists the codecs defined by this
 specification. CBOR-LD codecs are also intended as an extension point: a processing model MAY
-use codecs that are not specified here, but are instead defined by the
+use codecs that are not specified here, but are instead defined by a
 specification or other document that defines the processing model.
         </p>
         <p>
 This specification does
-not constrain how user-specified codecs behave or how they are specified.
+not constrain how user-specified codecs behave nor how they are specified.
 Documents that define a processing model using such codecs are
 responsible for specifying each one precisely enough for interoperable implementation,
 and bear the burden of testing and correctness. Codecs that are defined in this

--- a/index.html
+++ b/index.html
@@ -557,18 +557,16 @@ applies.
         <dd>
 OPTIONAL. A boolean indicating whether semantic compression is applied to JSON-LD terms. When
 absent, its value is `true`. When `true`, term identifiers are auto-generated as described in
-<a href="#semantic-compression"></a>; this specification does not define any alternative
-term-identifier assignment scheme.
+<a href="#semantic-compression"></a>.
         </dd>
         <dt>`codecs`</dt>
         <dd>
-OPTIONAL. A map from a <dfn>type key</dfn> to a <dfn>codec identifier</dfn>. A type key is
-either a JSON-LD type expressed as an IRI, or one of the reserved keys `url`, which matches
-node references and values whose term is defined with an `@type` of `@id`, and
-`none`, which matches values that have no type. A codec identifier is one of the values listed
-in <a href="#codec-identifiers"></a>. During conversion, the codec bound to a value's type key,
-if any, is used to compress and decompress that value. When `codecs` is absent, no generic
-typed-value codecs are applied.
+OPTIONAL. A map from a type to a <dfn>codec identifier</dfn>. Here, a type is
+either a JSON-LD type expressed as an IRI the reserved value `url`, which matches
+node references and values whose term is defined with an `@type` of `@id`. During
+conversion, the codec bound to a value's type, if any, is used to compress and decompress
+that value. When `codecs` is absent and the default processing model is not in use,
+no generic typed-value codecs are applied.
         </dd>
       </dl>
 
@@ -584,7 +582,7 @@ defines the corresponding codec.
             <tr>
               <th>Codec identifier</th>
               <th>Codec</th>
-              <th>Type key it is bound to in the <a>default processing model</a></th>
+              <th>Type it is bound to in the <a>default processing model</a></th>
             </tr>
           </thead>
           <tbody>
@@ -618,7 +616,7 @@ defines the corresponding codec.
 Expressed in this form, the <a>default processing model</a> enables semantic compression and
 binds each codec defined by this specification to the type it compresses:
         </p>
-        <pre class="example" title="The default processing model, expressed explicitly">
+        <pre class="example" title="The default processing model">
 processingModel:
   semanticCompression: true
   codecs:
@@ -628,18 +626,17 @@ processingModel:
     "https://w3id.org/security#multibase": multibase
         </pre>
         <p>
-Because this is the default, a registry entry MAY omit the `processingModel` member entirely
+A registry entry MAY omit the `processingModel` member entirely
 and obtain identical behavior.
         </p>
       </section>
-
       <section>
         <h3>Example: A Custom Processing Model</h3>
         <p>
-A registry entry can depart from the default. Consider a use case whose documents seldom
-reference external JSON-LD contexts — so semantic compression offers little benefit — but which
-frequently carry timestamps. A processing model for that use case might disable semantic
-compression and enable only the `xsd:dateTime` codec:
+If a user does not wish semantic compression to be used, or wishes different
+codecs to be used than those in the default processing model, a registry entry can specify a
+custom processing model. The following is an example of a processing model without semantic
+compression and for which only the `xsd-date-time` codec is used:
         </p>
         <pre class="example" title="A processing model with semantic compression disabled">
 processingModel:
@@ -647,12 +644,37 @@ processingModel:
   codecs:
     "http://www.w3.org/2001/XMLSchema#dateTime": xsd-date-time
         </pre>
+      </section>
+      <section>
+        <h3>User-Specified Codecs</h3>
         <p>
-An encoder using this model leaves JSON-LD terms uncompressed while still replacing
-`xsd:dateTime` values with their compact byte encodings. A decoder, having selected the same
-model from the registry entry identifier, inverts exactly those transformations. A custom model
-could equally bind a type to a codec introduced by another specification, or omit `codecs`
-entirely to perform semantic compression alone.
+<a href="#codec-identifiers"></a> lists the codecs defined by this
+specification. CBOR-LD codecs are also intended as an extension point: a processing model MAY
+use codecs that are not specified here, but are instead defined by the
+specification or other document that defines the processing model.
+        </p>
+        <p>
+This specification does
+not constrain how user-specified codecs behave or how they are specified.
+Documents that define a processing model using such codecs are
+responsible for specifying each one precisely enough for interoperable implementation,
+and bear the burden of testing and correctness.
+        </p>
+        <p>
+The following example shows a processing model that uses a codec that compresses IP address
+values of type `https://example.org/vocab#ip-address`
+        </p>
+        <pre class="example" title="A processing model that uses a user-specified codec">
+processingModel:
+  semanticCompression: true
+  codecs:
+    url: url
+    "http://www.w3.org/2001/XMLSchema#dateTime": xsd-date-time
+    "https://example.org/vocab#ip-address": ip-address
+        </pre>
+        <p>
+Where the `ip-address` codec's encoding and decoding behavior is algorithmically specified
+externally.
         </p>
       </section>
     </section>
@@ -893,7 +915,7 @@ to <a href="#convert-document-algorithm"></a>.
           </ol>
           </li>
           <li>
-Otherwise, set `jsonldDocument` to the result of parsing `cborldBytes`.
+Otherwise, set `jsonldDocument` to the result of decoding `suffix` from bytes to a map.
           </li>
           <li>
 Return `jsonldDocument`.

--- a/index.html
+++ b/index.html
@@ -562,7 +562,7 @@ absent, its value is `true`. When `true`, term identifiers are auto-generated as
         <dt>`codecs`</dt>
         <dd>
 OPTIONAL. A map from a type to a <dfn>codec identifier</dfn>. Here, a type is
-either a JSON-LD type expressed as an IRI the reserved value `url`, which matches
+either a JSON-LD type expressed as an IRI, or the reserved value `url`, which matches
 node references and values whose term is defined with an `@type` of `@id`. During
 conversion, the codec bound to a value's type, if any, is used to compress and decompress
 that value. When `codecs` is absent and the default processing model is not in use,
@@ -658,7 +658,8 @@ This specification does
 not constrain how user-specified codecs behave or how they are specified.
 Documents that define a processing model using such codecs are
 responsible for specifying each one precisely enough for interoperable implementation,
-and bear the burden of testing and correctness.
+and bear the burden of testing and correctness. Codecs that are defined in this
+specification MUST be identified with an IRI.
         </p>
         <p>
 The following example shows a processing model that uses a codec that compresses IP address


### PR DESCRIPTION
This PR adds a section clarifying the contents of a processing model and gives examples, including the default processing model.

Fixes #29 and #47.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/cbor-ld/pull/114.html" title="Last updated on Aug 26, 2026, 7:51 PM UTC (3a792aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cbor-ld/114/76ca03b...3a792aa.html" title="Last updated on Aug 26, 2026, 7:51 PM UTC (3a792aa)">Diff</a>